### PR TITLE
Fix header title link to go to project home

### DIFF
--- a/example/js/components/PageHeader.js
+++ b/example/js/components/PageHeader.js
@@ -3,7 +3,7 @@ import React from 'react';
 export default function() {
   return (
     <div className="page-header flex-item-fix">
-      <div className="title pull-left"><a href="/">exerslide</a></div>
+      <div className="title pull-left"><a href="/exerslide">exerslide</a></div>
       <div className="navigation pull-right">
         <a href="#/docs">Docs</a>
         <a href="https://github.com/facebookincubator/exerslide">GitHub</a>


### PR DESCRIPTION
Resolves the 404 pointing at the top-level GH Pages root.
