### PR TITLE
Properly escape backslashes on Windows

### DIFF
--- a/packages/exerslide/lib/builder.js
+++ b/packages/exerslide/lib/builder.js
@@ -132,9 +132,9 @@ function writeSlideFile(config) {
     'module.exports = [\n' +
       slides
         .map(p => (
-          'require("' + path.join(__dirname, './slide-loader') +
+          ('require("' + path.join(__dirname, './slide-loader') +
           '!' + path.relative(path.dirname(config.__slideFile__), p) +
-          '")'
+          '")').replace(/\\/g, "\\\\")
         ))
         .join(',\n') +
     '];'

--- a/packages/exerslide/lib/builder.js
+++ b/packages/exerslide/lib/builder.js
@@ -134,7 +134,7 @@ function writeSlideFile(config) {
         .map(p => (
           ('require("' + path.join(__dirname, './slide-loader') +
           '!' + path.relative(path.dirname(config.__slideFile__), p) +
-          '")').replace(/\\/g, "\\\\")
+          '")').replace(/\\/g, '\\\\')
         ))
         .join(',\n') +
     '];'


### PR DESCRIPTION
This should fix #12
